### PR TITLE
Adds simple discovery and some recovery logic to minimal broker layer

### DIFF
--- a/pmindb/Cargo.toml
+++ b/pmindb/Cargo.toml
@@ -13,3 +13,5 @@ ipnet = "2.9.0"
 thiserror = {version="1.0.59"}
 log = {version= "0.4.21"}
 futures = "0.3.30"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
+pmindp-sensor = {  path="../pmindp-sensor"}

--- a/pmindb/src/broker.rs
+++ b/pmindb/src/broker.rs
@@ -1,12 +1,12 @@
-use std::net::{Ipv6Addr, SocketAddr};
-use futures::prelude::*;
 use actix::{Actor, MailboxError};
 use coap_lite::{CoapRequest, ObserveOption, RequestType};
+use futures::prelude::*;
+use std::net::{Ipv6Addr, SocketAddr};
 use tokio::net::UdpSocket;
 
 use crate::{
-    monitor::{CheckNewChild, GetChildStatus, MonitorNetworkStatus, OmrIp},
-    OtMonitor, OtMonitorError,
+    monitor::{CheckNewNode, GetNodeStatus, MonitorNetworkStatus, NodeRegistered, OmrIp},
+    OtCliClient, OtMonitor, OtMonitorError,
 };
 
 use thiserror::Error;
@@ -27,19 +27,45 @@ pub enum BrokerCoordinatorError {
     AddrParse(#[from] std::net::AddrParseError),
 }
 
-
 pub struct BrokerCoordinator {
-
-    monitor_handle: tokio::task::JoinHandle<Result<(), BrokerCoordinatorError>>,
-    event_queue_handle: tokio::task::JoinHandle<Result<(), BrokerCoordinatorError>>, 
-
-    socket: UdpSocket,
+    monitor_handle: Option<tokio::task::JoinHandle<Result<(), BrokerCoordinatorError>>>,
+    event_queue_handle: Option<tokio::task::JoinHandle<Result<(), BrokerCoordinatorError>>>,
+    //socket: UdpSocket,
 }
 
 impl BrokerCoordinator {
+    pub async fn new() -> Result<Self, BrokerCoordinatorError> {
+        let ot_mon = OtMonitor::new(std::boxed::Box::new(OtCliClient));
 
-    pub async fn coap_observer_register(omr_addr: Ipv6Addr, ip_addr: Ipv6Addr) -> Result<(), BrokerCoordinatorError> {
+        let omr_addr = ot_mon.get_omr_ip()?;
+        let addr = format!("[{}]:1212", omr_addr);
+        let addr: std::net::SocketAddrV6 = addr.parse()?;
 
+        let socket = UdpSocket::bind(addr).await?;
+
+        let mut broker = Self {
+            monitor_handle: None,
+            event_queue_handle: None,
+        };
+
+        broker.spawn_socket_listener(socket).await;
+        broker.spawn_child_mon_task(25, ot_mon).await;
+
+        Ok(broker)
+    }
+
+    pub async fn exec_task_loops(&mut self) {
+        log::debug!("Starting event and monitor loop tasks...");
+        self.event_queue_handle.take().unwrap().await.ok();
+        self.monitor_handle.take().unwrap().await.ok();
+    }
+
+    pub async fn coap_observer_register(
+        omr_addr: Ipv6Addr,
+        ip_addr: Ipv6Addr,
+        port: u16,
+    ) -> Result<(), BrokerCoordinatorError> {
+        log::info!("Registering {:?}", ip_addr);
         let mut request: CoapRequest<SocketAddr> = CoapRequest::new();
         let mut buffer = [0u8; 512];
         // following https://datatracker.ietf.org/doc/html/rfc7641 observing resources in CoAP
@@ -53,26 +79,28 @@ impl BrokerCoordinator {
         // fix this later
         let send_addr: std::net::SocketAddrV6 = ip_w_port.parse()?;
 
-        let addr = format!("[{}]:1213", omr_addr.to_string());
+        let addr = format!("[{}]:{}", omr_addr, port);
         let addr: std::net::SocketAddrV6 = addr.parse()?;
-    
+
         let send_socket = UdpSocket::bind(addr).await?;
-    
+
         if let Err(e) = send_socket.send_to(&packet[..], send_addr).await {
             log::error!("Error sending: {e:}");
         }
 
         // allow retries in case the radio is currently idle
         // not currently enabling rx_on_when_idle, should only
-        // be a couple seconds 1 min max worst case
-        tokio::select!{
+        // be a couple seconds
+        tokio::select! {
             Ok((mut len, mut from)) = send_socket.recv_from(&mut buffer) => {
-                while len <= 0 {
+                while len == 0 {
                     // sleep a lil
                     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                     if let Err(e) = send_socket.send_to(&packet[..], send_addr).await {
                         log::error!("Error sending: {e:}");
                     }
+                    // TODO its UDP so should we not use TCP for the initial handshake???
+                    // need to look at CoAP spec
                     (len, from) = send_socket.recv_from(&mut buffer).await?
                 }
                 log::info!("Got a response from {from:}");
@@ -82,79 +110,127 @@ impl BrokerCoordinator {
 
             }
         };
-        
+
         Ok(())
     }
 
-    
     pub async fn spawn_socket_listener(&mut self, socket: UdpSocket) {
         let handle = tokio::spawn(async move {
             let mut buffer = [0u8; 512];
+            log::info!("Setting up listener on socket {:?}", socket);
 
-            loop {
+            while let Ok((len, src)) = socket.recv_from(&mut buffer).await {
+                if len > 0 {
+                    let mut moisture_s: [u8; 2] = [0u8; 2];
+                    moisture_s.copy_from_slice(&buffer[..2]);
+                    let moisture = u16::from_le_bytes(moisture_s);
+                    let mut temp_s: [u8; 4] = [0u8; 4];
+                    temp_s.copy_from_slice(&buffer[2..6]);
+                    let temp = f32::from_le_bytes(temp_s);
 
-                let (len, src) = socket.recv_from(&mut buffer).await?; 
-                    if len > 0 {
-                        let mut moisture_s: [u8; 2] = [0u8; 2];
-                        moisture_s.copy_from_slice(&buffer[..2]);
-                        let moisture = u16::from_le_bytes(moisture_s);
-                        let mut temp_s: [u8; 4] = [0u8; 4];
-                        temp_s.copy_from_slice(&buffer[2..6]);
-                        let temp = f32::from_le_bytes(temp_s);
-            
-                        println!("{:?} sent moisture: {:?} temp {:?}", src, moisture, temp);
-                    }
-                
+                    // TODO write these to an event queue
+                    println!("{:?} sent moisture: {:?} temp {:?}", src, moisture, temp);
+                }
             }
+            log::warn!("Socket listener task exiting");
+            // to do signal to broker to retstart this task ?
             Ok(())
         });
 
-        self.event_queue_handle = handle;
+        self.event_queue_handle = Some(handle);
     }
 
     pub async fn spawn_child_mon_task(&mut self, poll_interval: u64, ot_mon: OtMonitor) {
-        
         let addr = ot_mon.start();
         let poll = tokio::time::Duration::from_secs(poll_interval);
         let handle = tokio::spawn(async move {
+            log::info!(
+                "Setting up node / network monitor task to check every {:?} seconds",
+                poll_interval
+            );
             loop {
-                tokio::time::sleep(poll).await;
-                addr.send(MonitorNetworkStatus).await?.map_err(|e| {
-                    log::error!("Error checking omr prefix {e:}");
-                    e
-                })?;
+                log::debug!("Polling for network change");
 
-                if let Ok(children) = addr.send(CheckNewChild).await? {
+                addr.send(MonitorNetworkStatus)
+                    .await?
+                    .map_err(|e| {
+                        log::error!("Error checking omr prefix {e:}");
+                        e
+                    })
+                    .ok();
 
+                log::debug!("Polling for new nodes");
+                // yuck, need better logic here
+                if let Ok(nodes) = addr.send(CheckNewNode).await? {
                     if let Ok(omr_addr) = addr.send(OmrIp).await? {
+                        futures::stream::iter(nodes)
+                            .enumerate()
+                            .for_each(|(i, (rloc, ip))| {
+                                let addr_clone = addr.clone();
+                                async move {
+                                    // TODO + rloc as u16 for port
+                                    let res = BrokerCoordinator::coap_observer_register(
+                                        omr_addr,
+                                        ip,
+                                        1213 + i as u16,
+                                    )
+                                    .await
+                                    .map_err(|e| {
+                                        log::error!("failure to register coap observer {e:}");
+                                    });
 
-                        futures::stream::iter(children)
-                        .for_each(|ip| async move {
-                            let res =  BrokerCoordinator::coap_observer_register(omr_addr.clone(), ip).await;
-                            log::info!("Result: {:?}", res);
-                        })
-                        .await;
-
+                                    if res.is_ok() {
+                                        addr_clone
+                                            .send(NodeRegistered((rloc, ip)))
+                                            .await
+                                            .map_err(|e| log::error!("Failure to reg node {e:}"))
+                                            .ok();
+                                    }
+                                }
+                            })
+                            .await;
+                    } else {
+                        log::warn!("actor returned err on getting OmrIp");
+                        // break;
                     }
                 } else {
+                    log::warn!("actor returned err on CheckNewNode");
+                    // Break if we cant register new nodes
                     break;
                 }
 
-                if let Ok(lost_children) = addr.send(GetChildStatus).await? {
+                log::debug!("Polling for lost nodes");
+                if let Ok(lost_nodes) = addr.send(GetNodeStatus).await? {
                     // TODO need to handle this
-                    if !lost_children.is_empty() {
-                        log::warn!("Lost children {:?}", lost_children);
+                    if !lost_nodes.is_empty() {
+                        log::warn!("Lost nodes {:?}", lost_nodes);
                     }
                 } else {
-                    break;
+                    log::warn!("actor returned err on GetNodeStatus");
+                    // break;
                 }
+                tokio::time::sleep(poll).await;
             }
+
+            log::warn!("Node / network monitor task exiting");
+            // to do signal to broker to retstart this task ?
+
             //addr.terminate();
             //todo log somethin
             Ok(())
         });
 
-        self.monitor_handle = handle;
+        self.monitor_handle = Some(handle);
+    }
+}
 
+impl Drop for BrokerCoordinator {
+    fn drop(&mut self) {
+        if let Some(events) = &self.event_queue_handle {
+            events.abort();
+        }
+        if let Some(mon) = &self.monitor_handle {
+            mon.abort();
+        }
     }
 }

--- a/pmindb/src/db.rs
+++ b/pmindb/src/db.rs
@@ -1,0 +1,81 @@
+use pmindp_sensor::{ATSAMD10SensorReading, SensorReading};
+use rusqlite::{params, Connection, Error as SqliteErr, Result};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("I/O Error")]
+    Io(#[from] std::io::Error),
+    #[error("Sqlite Error")]
+    SqliteError(#[from] SqliteErr),
+}
+
+pub(crate) struct Plant {
+    sensor_id: u16, // node rloc
+    species: String,
+    //conditions
+}
+
+pub(crate) struct PlantDatabase {
+    path: std::path::PathBuf,
+    conn: Connection,
+    // tables: Vec<PlantTable>,
+}
+
+/*
+struct PlantTable {
+    name: String,
+   // date_created: <>
+  //  last_updated: <>
+  // size?
+    schema: String
+}*/
+
+impl PlantDatabase {
+    pub fn new(path: std::path::PathBuf) -> Result<Self, DatabaseError> {
+        let conn = Connection::open(path.clone())?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS plants (
+                sensor_id INTEGER PRIMARY KEY,
+                species TEXT NOT NULL
+            )",
+            (), // empty list of parameters.
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS readings (
+                sensor_id INTEGER PRIMARY KEY,
+                moisture INTEGER,
+                temperature FLOAT
+            )",
+            (), // empty list of parameters.
+        )?;
+
+        Ok(Self { path, conn })
+    }
+
+    //pub(crate) fn add_new_reading(reading: dyn SensorReading, sensor_id: u16) -> Result<(), DatabaseError>{
+
+    pub(crate) fn insert_reading(
+        &self,
+        reading: ATSAMD10SensorReading,
+        sensor_id: u16,
+    ) -> Result<(), DatabaseError> {
+        self.conn.execute(
+            "INSERT INTO readings (sensor_id, moisture, temperature) VALUES (?1), (?2), (?3)",
+            params![sensor_id, reading.moisture, reading.temperature],
+        )?;
+
+        Ok(())
+    }
+
+    pub(crate) fn add_new_plant(&self, plant: Plant) -> Result<(), DatabaseError> {
+        self.conn.execute(
+            "INSERT INTO readings (sensor_id, species) VALUES (?1), (?2), (?3)",
+            params![plant.sensor_id, plant.species],
+        )?;
+
+        Ok(())
+    }
+}

--- a/pmindb/src/lib.rs
+++ b/pmindb/src/lib.rs
@@ -10,10 +10,12 @@ use std::{net::Ipv6Addr, process::Command};
 use ipnet::Ipv6Net;
 
 mod broker;
+mod db;
 mod monitor;
 
 pub use broker::BrokerCoordinator;
-pub use monitor::{OtMonitor, OtMonitorError};
+pub(crate) use db::PlantDatabase;
+pub(crate) use monitor::{OtMonitor, OtMonitorError};
 
 pub trait OtClient: Send + Sync {
     fn get_child_ips(&self) -> Result<Vec<(String, Ipv6Addr)>, OtCliError>;

--- a/pmindd/Cargo.toml
+++ b/pmindd/Cargo.toml
@@ -15,12 +15,14 @@ linux-embedded-hal = {version = "0.4.0", default-features=false, features=["asyn
 xca9548a = {version="0.2.1", git="https://github.com/nand-nor/xca9548a-rs", branch="add/embedded-hal-async", features=["embedded-hal-async"], optional=true}
 thiserror = {version="1.0.59", optional=true}
 coap-lite = {version="0.12.0", features=["udp"],default-features=false, optional=true}
-
+actix = {version = "0.13.5", features=["macros"], optional=true}
+env_logger = {version= "0.11.3"}
+log = {version= "0.4.21"}
 
 [features]
 default=[]
 i2cmux_wired =  ["pmindp-sensor/async_i2cmux", "embedded-hal", "embedded-hal-async", "linux-embedded-hal", "xca9548a", "thiserror"]
-thread_mesh = ["coap-lite"] 
+thread_mesh = ["coap-lite", "actix"] 
 
 [[bin]]
 path = "./src/bin/i2cmux_wired/main.rs"

--- a/pmindd/src/bin/thread_mesh/main.rs
+++ b/pmindd/src/bin/thread_mesh/main.rs
@@ -5,7 +5,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     log::info!("Initializing broker & starting task loops");
-    let mut broker = BrokerCoordinator::new().await?;
+    let mut broker = BrokerCoordinator::new("./test.db".into()).await?;
 
     broker.exec_task_loops().await;
 

--- a/pmindd/src/bin/thread_mesh/main.rs
+++ b/pmindd/src/bin/thread_mesh/main.rs
@@ -1,69 +1,16 @@
-use coap_lite::{
-    CoapOption, CoapRequest, MessageClass, MessageType, ObserveOption, Packet, RequestType,
-    ResponseType,
-};
-use pmindd;
-use std::sync::Arc;
-use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
+use pmindb::BrokerCoordinator;
 
-use std::net::{Ipv6Addr, SocketAddr, UdpSocket};
-
-use pmindb::{OtCliClient, OtMonitor};
-
-#[tokio::main]
+#[actix::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut request: CoapRequest<SocketAddr> = CoapRequest::new();
+    env_logger::init();
 
-    // following https://datatracker.ietf.org/doc/html/rfc7641 observing resources in CoAP
-    request.set_method(RequestType::Get);
-    request.set_path("/soilmoisture");
-    request.message.set_token(vec![0xfa, 0xce, 0xbe, 0xef]);
-    request.set_observe_flag(ObserveOption::Register);
-    let packet = request.message.to_bytes().unwrap();
+    log::info!("Initializing broker & starting task loops");
+    let mut broker = BrokerCoordinator::new().await?;
 
-    let mut ot_mon = OtMonitor::new(std::boxed::Box::new(OtCliClient));
-
-    let omr_addr = ot_mon.get_omr_ip()?;
-    let addr = format!("[{}]:1212", omr_addr.to_string());
-    let addr: std::net::SocketAddrV6 = addr.parse()?;
-
-    let socket = UdpSocket::bind(addr).unwrap();
-
-    let children = ot_mon.get_children()?;
-    let mut buffer = [0u8; 512];
-
-    children.iter().for_each(|ip| {
-        let ip_w_port = format!("[{}]:1212", ip.clone());
-        // fix this later
-        let send_addr: std::net::SocketAddrV6 = ip_w_port.parse().unwrap();
-
-        let mut len = 0;
-        // allow retries in case the radio is currently idle
-        // not currently enabling rx_on_when_idle, should only
-        // be a couple seconds 1 min max worst case
-        while len <= 0 {
-            if let Err(e) = socket.send_to(&packet[..], send_addr) {
-                std::process::exit(1);
-            }
-            len = socket.recv(&mut buffer).unwrap();
-        }
-    });
-
-    println!("Sent CoAP observe registration");
+    broker.exec_task_loops().await;
 
     loop {
-        let (len, src) = socket.recv_from(&mut buffer).unwrap();
-        if len > 0 {
-            let mut moisture_s: [u8; 2] = [0u8; 2];
-            moisture_s.copy_from_slice(&buffer[..2]);
-            let moisture = u16::from_le_bytes(moisture_s);
-            let mut temp_s: [u8; 4] = [0u8; 4];
-            temp_s.copy_from_slice(&buffer[2..6]);
-            let temp = f32::from_le_bytes(temp_s);
-
-            println!("{:?} sent moisture: {:?} temp {:?}", src, moisture, temp);
-        }
+        // todo block on broker or SIGINT / SIGQUIT / SIGSTP from stdin
     }
 
     Ok(())

--- a/pmindp-esp32-thread/src/bin/main.rs
+++ b/pmindp-esp32-thread/src/bin/main.rs
@@ -185,7 +185,17 @@ fn main() -> ! {
                             // TODO depending on the error, need to set handshake IPv6 to None
                             // until observer can reestablish conn; this will prevent the
                             // node from sending data until success is better guaranteed
-                            println!("Error sending {:?}", e);
+                            println!("Error sending, print all ips??? {:?}", e);
+                            //socket.close();
+
+                            critical_section::with(|cs| {
+                                let mut c = changed.borrow_ref_mut(cs);
+
+                                let addrs: heapless::Vec<NetworkInterfaceUnicastAddress, 6> =
+                                    openthread.ipv6_get_unicast_addresses();
+
+                                print_all_addresses(addrs);
+                            });
                         } else {
                             data = [colors::MISTY_ROSE];
                             led.write(brightness(gamma(data.iter().cloned()), 100)).ok();

--- a/pmindp-sensor/src/lib.rs
+++ b/pmindp-sensor/src/lib.rs
@@ -82,6 +82,15 @@ pub struct ATSAMD10<I2C: I2c> {
     pub i2c: I2C,
 }
 
+pub trait SensorReading {}
+
+impl SensorReading for ATSAMD10SensorReading {}
+
+pub struct ATSAMD10SensorReading {
+    pub moisture: u16,
+    pub temperature: f32,
+}
+
 // NOTE: can use something like this later
 // when ready to implement different soil
 // sensor types, for now only using ATSAMD10


### PR DESCRIPTION
Adds some minimal code for a simple broker layer that does the following:
1. Maintains list of active nodes (currently only MTDs) and their OMR IPv6 addresses
2. For each active, unregistered node discovered:
   a. Register observer client on discovered node (to start receiving sensor data)
   b. Manage socket to receive sensor data, post observer registration
   c. Notify if/when when a registered node drops off the network
   d. continually check (currently every 25 seconds) for new or dropped nodes, or any network changes that would impact how nodes are addressed via RPI application layer (such as changed OMR prefix)

If nodes fall off the network but are later able to rejoin, then the polling should re-register those nodes to start collecting sensor data again