### PR TITLE
Add/more fault tolerance

### DIFF
--- a/pmindb/Cargo.toml
+++ b/pmindb/Cargo.toml
@@ -17,3 +17,4 @@ rusqlite = { version = "0.31.0", features = ["bundled"] }
 pmindp-sensor = {  path="../pmindp-sensor", features=["std"]}
 tokio-stream = "0.1.15"
 chrono = {version="0.4.38"}
+serde_json = {version = "1.0"}

--- a/pmindb/src/broker.rs
+++ b/pmindb/src/broker.rs
@@ -144,12 +144,7 @@ impl BrokerCoordinator {
                     log::warn!("Node {:?} timed out, closing receiver stream", addr);
                 }
                 NodeEvent::SensorReading(node) => {
-                    log::debug!(
-                        "Reading! from {:?} moisture {:?} temp {:?}",
-                        node.addr,
-                        node.data.moisture,
-                        node.data.temperature
-                    );
+                    log::debug!("Reading! from {:?} data {:?}", node.addr, node.data);
 
                     if let Err(e) = db_clone
                         .send(NodeSensorReading((*node.addr.ip(), node.data)))

--- a/pmindb/src/db.rs
+++ b/pmindb/src/db.rs
@@ -68,7 +68,7 @@ impl PlantDatabase {
     ) -> Result<(), DatabaseError> {
         self.conn.execute(
             "INSERT INTO readings (sensor_id, moisture, temperature) VALUES (?1), (?2), (?3)",
-            params![sensor_id, reading.moisture, reading.temperature],
+            params![sensor_id, reading.soil.moisture, reading.soil.temperature],
         )?;
 
         Ok(())

--- a/pmindd/src/event.rs
+++ b/pmindd/src/event.rs
@@ -194,10 +194,9 @@ async fn sensor_stream_process(
             }
             NodeEvent::SensorReading(node) => {
                 log::debug!(
-                    "Reading! from {:?} moisture {:?} temp {:?}",
+                    "Node event: sensor reading! from {:?} data {:?}",
                     node.addr,
-                    node.data.moisture,
-                    node.data.temperature
+                    node.data
                 );
 
                 if let Err(e) = sender_clone.send(node) {

--- a/pmindd/src/minder.rs
+++ b/pmindd/src/minder.rs
@@ -192,7 +192,7 @@ impl PlantMinder {
                     "Waiting".to_string()
                 } else {
                     let last = node.history.len();
-                    match node.history[last - 1].data.moisture {
+                    match node.history[last - 1].data.soil.moisture {
                         750..=1000 => "Good & moist".to_string(),
                         501..=749 => "Ok (for now)".to_string(),
                         401..=500 => "Danger Zone".to_string(),
@@ -363,8 +363,9 @@ pub struct Tui {
 
 impl Tui {
     // TODO toml file, make this configurable
-    const TERM_COL: u16 = 110;
-    const TERM_ROW: u16 = 30;
+    // for now optimize for my LCD screen
+    const TERM_COL: u16 = 125;
+    const TERM_ROW: u16 = 35;
 
     pub fn new() -> Result<Self, std::io::Error> {
         // keep track of prev terminal size before resizing

--- a/pmindd/src/ui/history.rs
+++ b/pmindd/src/ui/history.rs
@@ -298,20 +298,20 @@ impl Widget for NodeHistory<'_> {
                 }
 
                 if max_l == 0.0 {
-                    max_l = h.data.full_spectrum as f64;
+                    max_l = h.data.light.full_spectrum as f64;
                 }
 
-                if (h.data.full_spectrum as f64) < max_l {
-                    max_l = h.data.full_spectrum as f64;
+                if (h.data.light.full_spectrum as f64) < max_l {
+                    max_l = h.data.light.full_spectrum as f64;
                 }
 
                 let timestamp = h.data.timestamp as f64;
 
                 let reading = match self.view {
-                    HistoryView::Lux => h.data.lux as f64,
-                    HistoryView::Lumens => h.data.full_spectrum as f64,
-                    HistoryView::Temp => h.data.temperature as f64,
-                    HistoryView::Moisture => h.data.moisture as f64,
+                    HistoryView::Lux => h.data.light.lux as f64,
+                    HistoryView::Lumens => h.data.light.full_spectrum as f64,
+                    HistoryView::Temp => h.data.soil.temperature as f64,
+                    HistoryView::Moisture => h.data.soil.moisture as f64,
                 };
                 (
                     timestamp, // x is time

--- a/pmindp-esp32-thread/.cargo/config.toml
+++ b/pmindp-esp32-thread/.cargo/config.toml
@@ -7,7 +7,7 @@ rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
-  "-C", "force-frame-pointers",
+  #"-C", "force-frame-pointers",
 
   # needed by 802.15.4
   "-C", "link-arg=-Trom_coexist.x",

--- a/pmindp-esp32-thread/Cargo.toml
+++ b/pmindp-esp32-thread/Cargo.toml
@@ -23,9 +23,11 @@ smart-leds = {version= "0.4.0" }
 esp-openthread = { git = "https://github.com/nand-nor/esp-openthread.git", branch="add-more-mtd-support"}
 coap-lite = {version="0.12.0", features=["udp"],default-features=false}
 pmindp-sensor = {  path="../pmindp-sensor"}
+serde_json = {version = "1.0", default-features=false, features = ["alloc"] } 
+
 
 [features]
-default = ["esp32c6","atsamd10","tsl2591"]
+default = [] #"esp32c6","atsamd10"]
 esp32c6 = [ "esp-hal/esp32c6", "esp-ieee802154/esp32c6", "esp-openthread/esp32c6", "esp-backtrace/esp32c6", "esp-println/esp32c6", "esp-hal-smartled/esp32c6" ]
 esp32h2 = [ "esp-hal/esp32h2", "esp-ieee802154/esp32h2", "esp-openthread/esp32h2", "esp-backtrace/esp32h2", "esp-println/esp32h2", "esp-hal-smartled/esp32h2" ]
 probe-circuit = []

--- a/pmindp-esp32-thread/src/bin/main.rs
+++ b/pmindp-esp32-thread/src/bin/main.rs
@@ -48,6 +48,8 @@ fn main() -> ! {
     let mut ieee802154 = Ieee802154::new(peripherals.IEEE802154, &mut peripherals.RADIO_CLK);
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
+
+    #[cfg(not(feature = "esp32h2"))]
     let i2c = I2C::new(
         peripherals.I2C0,
         io.pins.gpio5,
@@ -55,10 +57,20 @@ fn main() -> ! {
         400.kHz(),
         &clocks,
     );
+    #[cfg(feature = "esp32h2")]
+    let i2c = I2C::new(
+        peripherals.I2C0,
+        io.pins.gpio2,
+        io.pins.gpio3,
+        400.kHz(),
+        &clocks,
+    );    
+
     let i2c_ref_cell = RefCell::new(i2c);
     let i2c_ref_cell: &'static _ = Box::leak(Box::new(i2c_ref_cell));
 
-    let mut sensors: Vec<Mutex<RefCell<Box<dyn Sensor>>>> = Vec::with_capacity(pmindp_sensor::MAX_SENSORS);
+    let mut sensors: Vec<Mutex<RefCell<Box<dyn Sensor>>>> =
+        Vec::with_capacity(pmindp_sensor::MAX_SENSORS);
 
     // Require at least a moisture sensor
     cfg_if::cfg_if! {

--- a/pmindp-esp32-thread/src/bin/main.rs
+++ b/pmindp-esp32-thread/src/bin/main.rs
@@ -18,7 +18,7 @@ extern crate alloc;
 
 //#[cfg(feature = "atsamd10")]
 //use esp_hal::i2c::I2C;
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 use pmindp_sensor::Sensor;
 
@@ -58,7 +58,7 @@ fn main() -> ! {
     let i2c_ref_cell = RefCell::new(i2c);
     let i2c_ref_cell: &'static _ = Box::leak(Box::new(i2c_ref_cell));
 
-    let mut sensors: Vec<Mutex<RefCell<Box<dyn Sensor>>>> = vec![];
+    let mut sensors: Vec<Mutex<RefCell<Box<dyn Sensor>>>> = Vec::with_capacity(pmindp_sensor::MAX_SENSORS);
 
     // Require at least a moisture sensor
     cfg_if::cfg_if! {
@@ -71,7 +71,7 @@ fn main() -> ! {
                 delay: Delay::new(&clocks)
             };
 
-            sensors.push(Mutex::new(RefCell::new(Box::new(soil_sensor))));
+            sensors.insert(pmindp_sensor::SOIL_IDX, Mutex::new(RefCell::new(Box::new(soil_sensor))));
 
         } else if #[cfg(feature="probe-circuit")] {
             let soil_sensor = pmindp_esp32_thread::ProbeCircuit::new(
@@ -83,7 +83,7 @@ fn main() -> ! {
                 peripherals.ADC1,
                 Delay::new(&clocks)
             );
-            sensors.push(Mutex::new(RefCell::new(Box::new(soil_sensor))));
+            sensors.insert(pmindp_sensor::SOIL_IDX, Mutex::new(RefCell::new(Box::new(soil_sensor))));
         } else {
             log::error!("No sensor target specified!");
             panic!("No sensors specified")
@@ -98,7 +98,7 @@ fn main() -> ! {
                 0x29,
                 Delay::new(&clocks)
             ).unwrap();
-            sensors.push(Mutex::new(RefCell::new(Box::new(light_sensor))));
+            sensors.insert(pmindp_sensor::LIGHT_IDX_1, Mutex::new(RefCell::new(Box::new(light_sensor))));
         }
     }
 

--- a/pmindp-esp32-thread/src/bin/main.rs
+++ b/pmindp-esp32-thread/src/bin/main.rs
@@ -48,7 +48,6 @@ fn main() -> ! {
     let mut ieee802154 = Ieee802154::new(peripherals.IEEE802154, &mut peripherals.RADIO_CLK);
     let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
 
-
     #[cfg(not(feature = "esp32h2"))]
     let i2c = I2C::new(
         peripherals.I2C0,
@@ -64,7 +63,7 @@ fn main() -> ! {
         io.pins.gpio3,
         400.kHz(),
         &clocks,
-    );    
+    );
 
     let i2c_ref_cell = RefCell::new(i2c);
     let i2c_ref_cell: &'static _ = Box::leak(Box::new(i2c_ref_cell));

--- a/pmindp-esp32-thread/src/lib.rs
+++ b/pmindp-esp32-thread/src/lib.rs
@@ -32,7 +32,12 @@ mod sensor;
 
 pub use crate::{
     platform::Esp32Platform,
-    sensor::{ProbeCircuit, ATSAMD10, TSL2591},
+    sensor::{ATSAMD10, TSL2591},
+};
+
+#[cfg(not(feature = "esp32h2"))]
+pub use crate::{
+    sensor::ProbeCircuit,
 };
 
 use core::{cell::RefCell, ptr::addr_of_mut};

--- a/pmindp-esp32-thread/src/lib.rs
+++ b/pmindp-esp32-thread/src/lib.rs
@@ -36,9 +36,7 @@ pub use crate::{
 };
 
 #[cfg(not(feature = "esp32h2"))]
-pub use crate::{
-    sensor::ProbeCircuit,
-};
+pub use crate::sensor::ProbeCircuit;
 
 use core::{cell::RefCell, ptr::addr_of_mut};
 use critical_section::Mutex;
@@ -72,7 +70,9 @@ pub fn init_heap() {
     unsafe { ALLOC.init(addr_of_mut!(HEAP) as *mut u8, SIZE) }
 }
 
-static SENSOR_TIMER: Mutex<RefCell<Option<Timer<Timer0<TIMG0>, esp_hal::Blocking>>>> =
+type SensorTimer = Mutex<RefCell<Option<Timer<Timer0<TIMG0>, esp_hal::Blocking>>>>;
+
+static SENSOR_TIMER: SensorTimer =
     Mutex::new(RefCell::new(None));
 
 const DEFAULT_MIN_INTERVAL: u64 = 5000;
@@ -81,6 +81,8 @@ static SENSOR_TIMER_INTERVAL: Mutex<RefCell<u64>> = Mutex::new(RefCell::new(DEFA
 
 static SENSOR_TIMER_FIRED: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));
 
+// TODO builder?
+#[allow(clippy::too_many_arguments)]
 pub fn init<'a>(
     ieee802154: &'a mut Ieee802154,
     clocks: &Clocks,

--- a/pmindp-esp32-thread/src/platform.rs
+++ b/pmindp-esp32-thread/src/platform.rs
@@ -85,7 +85,7 @@ where
 
             ..OperationalDataset::default()
         };
-        log::info!("dataset : {:?}", dataset);
+        log::debug!("Programmed child device with dataset : {:?}", dataset);
 
         self.openthread.set_active_dataset(dataset).unwrap();
         self.openthread.set_child_timeout(60).unwrap();
@@ -97,6 +97,8 @@ where
         let mut data;
         let mut eui: [u8; 6] = [0u8; 6];
 
+        let mut sensor_error_count = 0;
+
         let mut observer_addr: Option<(no_std_net::Ipv6Addr, u16)> = None;
         // This block is needed to constrain how long the immutable borrow of openthread,
         // which happens when the socket object is created, exists
@@ -106,7 +108,7 @@ where
             socket.bind(BOUND_PORT).unwrap();
 
             // make this big
-            let mut send_data_buf: [u8; 56] = [0u8; 56];
+            let mut send_data_buf: [u8; 127] = [0u8; 127];
             loop {
                 self.openthread.process();
                 self.openthread.run_tasklets();
@@ -123,26 +125,45 @@ where
                         res
                     });
 
-                    if read_sensor && self.sensor_read(&mut send_data_buf).is_ok() {
-                        let role = self.openthread.get_device_role();
-                        log::info!("Role: {:?}", role);
-
-                        if let Err(e) = socket.send(observer, port, &send_data_buf) {
-                            // TODO depending on the error, need to set handshake IPv6 to None
-                            // until observer can reestablish conn; this will prevent the
-                            // node from sending data until success is better guaranteed
-                            log::info!(
-                                "Error sending, first print all ips??? then reset due to {:?}",
-                                e
-                            );
-                            socket.close().ok();
-                            break;
-                        } else {
-                            data = [colors::MISTY_ROSE];
-                            self.led
-                                .write(brightness(gamma(data.iter().cloned()), 100))
-                                .ok();
-                        }
+                    if read_sensor {
+                        match self.sensor_read(&mut send_data_buf) {
+                            Ok(r) => {
+                                if let Ok(sensor_data) = serde_json::to_vec(&r) {
+                                    let len = sensor_data.len();
+                                    if let Err(e) = socket.send(observer, port, &sensor_data[0..len]) {
+                                        // TODO depending on the error, need to set handshake IPv6 to None
+                                        // until observer can reestablish conn; this will prevent the
+                                        // node from sending data until success is better guaranteed
+                                        log::error!("Error sending, resetting due to {e:?}");
+                                        socket.close().ok();
+                                        break;
+                                    } else {
+                                        data = [colors::MISTY_ROSE];
+                                        self.led
+                                            .write(brightness(gamma(data.iter().cloned()), 100))
+                                            .ok();
+                                    }
+                                } else {
+                                    log::error!("Unable to serialize sensor data");
+                                }
+                            }
+                            Err(PlatformSensorError::LightSensorError(_e)) => {
+                                // TODO instead of breaking here, we should dynamically adjust the gain on the 
+                                // light sensor to adjust to changing light conditions
+                                // so need to match on LightSensorError::SensorError which is what is returned
+                                // when there is overflow on read
+                                if sensor_error_count == 1000 {
+                                    log::error!("Reached max error count for light sensor error, resetting");
+                                    break;
+                                } else {
+                                    sensor_error_count += 1;
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("Sensor error, resetting due to {e:?}");
+                                break;
+                            }
+                        };
                     }
                 }
 
@@ -223,21 +244,55 @@ fn print_all_addresses(addrs: heapless::Vec<NetworkInterfaceUnicastAddress, 6>) 
 // sensors to write to, since a variable number of sensors could be
 // attached
 impl<'a> SensorPlatform for Esp32Platform<'a> {
-    fn sensor_read(&self, buffer: &mut [u8]) -> Result<(), PlatformSensorError> {
-        // track write indices so read ops can write to the buffer in the correct place
+    fn sensor_read(
+        &self,
+        buffer: &mut [u8],
+    ) -> Result<pmindp_sensor::SensorReading, PlatformSensorError> {
+        let mut d = pmindp_sensor::SensorReading::default();
+
         let mut start = 0;
-        self.sensors.iter().for_each(|s| {
+        self.sensors.iter().enumerate().for_each(|(idx, s)| {
             if let Ok(size) = critical_section::with(|cs| {
                 let mut sensor = s.borrow_ref_mut(cs);
                 let size = sensor.read(buffer, start)?;
                 Ok(size)
             })
             .map_err(|e: PlatformSensorError| {
-                log::error!("Error reading from light sensor {e:?}");
+                log::error!("Error reading from sensor {e:?}");
+                e
             }) {
+                match idx {
+                    pmindp_sensor::SOIL_IDX => {
+                        if let Ok(soil_reading) =
+                            serde_json::from_slice(&buffer[start..start + size]).map_err(|e| {
+                                log::error!("Unable to serialize soil :( {e:}");
+                                PlatformSensorError::Other
+                            })
+                        {
+                            d.soil = soil_reading;
+                        }
+                    }
+                    pmindp_sensor::LIGHT_IDX_1 => {
+                        if let Ok(light_reading) =
+                            serde_json::from_slice(&buffer[start..start + size])
+                        {
+                            d.light = light_reading;
+                        } else {
+                            log::error!("Unable to serialize light :(");
+                        }
+                    }
+                    // pmindp_sensor::HUM_IDX=>{},
+                    // pmindp_sensor::LIGHT_IDX_2 =>{},
+                    // pmindp_sensor::OTHER_IDX=>{},
+                    _ => {
+                        // all other types are currently unsupported
+                    }
+                };
+
                 start = start + size;
             }
         });
-        Ok(())
+        d.timestamp = 0;
+        Ok(d)
     }
 }

--- a/pmindp-esp32-thread/src/sensor/atsamd10.rs
+++ b/pmindp-esp32-thread/src/sensor/atsamd10.rs
@@ -1,10 +1,9 @@
+use core::result::Result;
+use core::result::Result::Ok;
 /// [Seesaw soil sensor](https://www.adafruit.com/product/4026)
-
 use embedded_hal::i2c::I2c;
 use esp_hal::delay::Delay;
 use pmindp_sensor::{MoistureSensor, PlatformSensorError, Sensor, SoilSensorError, TempSensor};
-use core::result::Result;
-use core::result::Result::Ok;
 
 /// Seesaw I2C Soil Sensor
 pub struct ATSAMD10<I2C: I2c> {

--- a/pmindp-esp32-thread/src/sensor/mod.rs
+++ b/pmindp-esp32-thread/src/sensor/mod.rs
@@ -1,7 +1,7 @@
 mod atsamd10;
 #[cfg(not(feature = "esp32h2"))]
 mod probe_circuit;
-mod st0160;
+//mod st0160;
 mod tsl2591;
 
 //#[cfg(all(feature = "probe-circuit", not(feature = "atsamd10", feature = "st0160")))]
@@ -12,6 +12,6 @@ pub use probe_circuit::ProbeCircuit;
 pub use atsamd10::ATSAMD10;
 
 //#[cfg(all(feature = "st0160", not(feature = "atsamd10", feature = "probe-circuit")))]
-pub use st0160::ST0160;
+//pub use st0160::ST0160;
 
 pub use tsl2591::TSL2591;

--- a/pmindp-esp32-thread/src/sensor/mod.rs
+++ b/pmindp-esp32-thread/src/sensor/mod.rs
@@ -1,9 +1,11 @@
 mod atsamd10;
+#[cfg(not(feature = "esp32h2"))]
 mod probe_circuit;
 mod st0160;
 mod tsl2591;
 
 //#[cfg(all(feature = "probe-circuit", not(feature = "atsamd10", feature = "st0160")))]
+#[cfg(not(feature = "esp32h2"))]
 pub use probe_circuit::ProbeCircuit;
 
 //#[cfg(all(feature = "atsamd10", not(feature = "probe-circuit", feature = "st0160")))]

--- a/pmindp-esp32-thread/src/sensor/probe_circuit.rs
+++ b/pmindp-esp32-thread/src/sensor/probe_circuit.rs
@@ -79,7 +79,7 @@ impl<'a> MoistureSensor for ProbeCircuit<'a> {
 impl<'a> Sensor for ProbeCircuit<'a> {
     fn read(&mut self, buffer: &mut [u8], start: usize) -> Result<usize, PlatformSensorError> {
         let size = <Self as MoistureSensor>::moisture(self, buffer, start)
-            .map_err(|e| PlatformSensorError::from(e))?;
+            .map_err(PlatformSensorError::from)?;
         Ok(size)
     }
 }

--- a/pmindp-sensor/Cargo.toml
+++ b/pmindp-sensor/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["nand-nor <a13xandra.cliff0rd@gmail.com>"]
 
 [dependencies]
 embedded-hal = {version = "1.0"}
+serde_json = {version = "1.0", default-features=false, features = ["alloc"] } # optional=true}
+serde = {version="1.0", default-features=false, features = ["derive"] }
 
 [features]
 default=[]

--- a/pmindp-sensor/src/lib.rs
+++ b/pmindp-sensor/src/lib.rs
@@ -13,20 +13,44 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[derive(Debug, Clone, Copy)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
 pub struct SensorReading {
+    pub soil: SoilSensorReading,
+    #[serde(default)]
+    /// If no light sensor is configured,
+    /// then these should be populated with 0s
+    pub light: LightSensorReading,
+    #[serde(default)]
+    pub timestamp: i64,
+}
+
+pub const MAX_SENSORS: usize = 5;
+pub const SOIL_IDX: usize = 0;
+pub const LIGHT_IDX_1: usize = 1;
+pub const HUM_IDX: usize = 2;
+pub const LIGHT_IDX_2: usize = 3;
+pub const OTHER_IDX: usize = 4;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
+pub struct SoilSensorReading {
     pub moisture: u16,
+    #[serde(default)]
     pub temperature: f32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
+pub struct LightSensorReading {
     pub full_spectrum: u16,
     pub lux: f32,
-    pub timestamp: i64, // filled in by broker
 }
 
 /// [`SensorPlatform`] trait defines the sensor read operation for the platform,
 /// which is configured to hold a vec of dynamic [`Sensor`] objects to
 /// allow support for different sensor types
 pub trait SensorPlatform {
-    fn sensor_read(&self, buff: &mut [u8]) -> Result<(), PlatformSensorError>;
+    fn sensor_read(&self, buff: &mut [u8]) -> Result<SensorReading, PlatformSensorError>;
 }
 
 /// [`Sensor`] trait defines the base sensor read operation, to allow support for

--- a/pmindp-sensor/src/lib.rs
+++ b/pmindp-sensor/src/lib.rs
@@ -62,6 +62,11 @@ pub trait SensorPlatform {
 /// device-specific data read ops
 pub trait Sensor {
     fn read(&mut self, buffer: &mut [u8], index: usize) -> Result<usize, PlatformSensorError>;
+    /// some sensors may require dynamic configuration
+    fn dynamic_config(&mut self) -> Result<(), PlatformSensorError> {
+        // noop for default def
+        Ok(())
+    }
 }
 
 /// allows device-specific impls of moisture-specific sensor functionality
@@ -96,6 +101,7 @@ pub enum LightSensorError {
     I2cError(I2cError),
     SetupError,
     SensorError,
+    SignalOverflow,
 }
 
 impl From<I2cError> for LightSensorError {


### PR DESCRIPTION
Adds the following:
- `serde` derives for sending/receiving sensor data-- can now use `serde_json` on the received buffer. 
    - As a follow up I need to integrate this into the database logic / ORM
- Adds specific config for `esp32h2` targets (now using gpio2 and gpio3 for SDA/SCL for `esp32h2` and gpio5 & gpio6 on `esp32c6`)
- Adds a method to allow the platform to dynamically adjust light sensor gain and integration time in response to signal overflow, which can happen in bright light conditions