### PR TITLE
pin to esp-hal rev c0a9934 for stability

### DIFF
--- a/pmindp-esp32-thread/Cargo.toml
+++ b/pmindp-esp32-thread/Cargo.toml
@@ -9,18 +9,16 @@ bitflags = "2.6.0"
 cfg-if = "1.0.0"
 embedded-hal = {version = "1.0.0"} 
 embedded-hal-bus = {version = "0.2.0" }
-esp-hal = {version= "0.20.1", git = "https://github.com/esp-rs/esp-hal.git"}
-esp-backtrace = { version="0.14.0", git = "https://github.com/esp-rs/esp-hal.git", features = ["panic-handler", "exception-handler", "println"]}
-esp-println       = { version= "0.11.0", git = "https://github.com/esp-rs/esp-hal.git", features = ["log"]}
-esp-ieee802154 = {version= "0.2.0", git = "https://github.com/esp-rs/esp-hal.git"}
-esp-hal-smartled = { git = "https://github.com/esp-rs/esp-hal.git"}
-esp-alloc = { version="0.4.0", git = "https://github.com/esp-rs/esp-hal.git"} 
+esp-hal = {version= "0.20.1", git = "https://github.com/esp-rs/esp-hal.git", rev="c0a9934"}
+esp-backtrace = { version="0.14.0", git = "https://github.com/esp-rs/esp-hal.git", features = ["panic-handler", "exception-handler", "println"], rev="c0a9934"}
+esp-println       = { version= "0.11.0", git = "https://github.com/esp-rs/esp-hal.git", features = ["log"], rev="c0a9934"}
+esp-ieee802154 = {version= "0.2.0", git = "https://github.com/esp-rs/esp-hal.git", rev="c0a9934"}
+esp-alloc = { version="0.4.0", git = "https://github.com/esp-rs/esp-hal.git", rev="c0a9934"} 
 log = {version= "0.4.21"}
 heapless = {version= "0.8.0"}
 no-std-net = {version= "0.6.0"}
 critical-section = {version= "1.1.0"}
-smart-leds = {version= "0.4.0" }
-esp-openthread = { version= "0.2.0", git = "https://github.com/nand-nor/esp-openthread.git", branch="add-more-mtd-support"}
+esp-openthread = { version= "0.4.0", git = "https://github.com/nand-nor/esp-openthread.git", rev="522e6c9"}
 coap-lite = {version="0.12.0", features=["udp"],default-features=false}
 pmindp-sensor = {  path="../pmindp-sensor"}
 serde_json = {version = "1.0", default-features=false, features = ["alloc"] } 
@@ -31,8 +29,8 @@ sht4x = { version = "0.2.0", git = "https://github.com/hawkw/sht4x", branch="eli
 
 [features]
 default = []
-esp32c6 = [ "esp-hal/esp32c6", "esp-ieee802154/esp32c6", "esp-openthread/esp32c6", "esp-backtrace/esp32c6", "esp-println/esp32c6", "esp-hal-smartled/esp32c6" ]
-esp32h2 = [ "esp-hal/esp32h2", "esp-ieee802154/esp32h2", "esp-openthread/esp32h2", "esp-backtrace/esp32h2", "esp-println/esp32h2", "esp-hal-smartled/esp32h2" ]
+esp32c6 = [ "esp-hal/esp32c6", "esp-ieee802154/esp32c6", "esp-openthread/esp32c6", "esp-backtrace/esp32c6", "esp-println/esp32c6"] #, "esp-hal-smartled/esp32c6" ]
+esp32h2 = [ "esp-hal/esp32h2", "esp-ieee802154/esp32h2", "esp-openthread/esp32h2", "esp-backtrace/esp32h2", "esp-println/esp32h2"] #, "esp-hal-smartled/esp32h2" ]
 probe-circuit = []
 atsamd10 = []
 st0160 = []


### PR DESCRIPTION
Pins to a specific git commit of the `esp-hal` for some stability while that API stabilizes (may not be any time soon). Also gets rid of fun LED color patterns :( `esp-hal-smartled` has moved out of the scope of the `esp-hal` repo/workspace and into a separate `esp-hal-community`, which is pinned to a different revision. Will revisit this later